### PR TITLE
Add example code for Python 2

### DIFF
--- a/codechecklib/example_code.py
+++ b/codechecklib/example_code.py
@@ -32,6 +32,7 @@ int main() {
     println!("Hello, world!");
 }''',
     'hs': '''main = putStrLn "Hello, world!"''',
+    'py2': 'print \'Hello, world!\''
 }
 EXAMPLE_CODES['py_nl'] = EXAMPLE_CODES['py']
 


### PR DESCRIPTION
This is needed for proper work of any code which will try to get an example code of all languages listed in const.COMPILE_COMMANDS etc.

P.S.: Yes, code for Python 3 could be used too, but I think the version with spaces is more Python2-ic and underlines one of the main differences between Python major versions 2 and 3.